### PR TITLE
Tim edits

### DIFF
--- a/calibrator_utils.py
+++ b/calibrator_utils.py
@@ -262,6 +262,7 @@ def check_cal_clock(calh5parm,verbose=False):
 ## so probably the above code can be merged with something that does the important stuff?
 
 def isint(ant):
+    ant = str(ant)
     return not(ant.startswith('CS') or ant.startswith('RS'))
 
 def check_int_stations(calh5parm,verbose=False,n_req=9):
@@ -281,7 +282,8 @@ def check_int_stations(calh5parm,verbose=False,n_req=9):
         v = data['calibrator']['clock']['val'][:]
         #clock=cal.getSoltab('clock')
         #v,a=clock.getValues()
-        good=[ant for ant in a['ant'] if isint(ant)]
+        print(a)
+        good=[ant for ant in a if isint(ant)]
         count=len(good)
         d['n_int']=count
         if count==0:
@@ -289,12 +291,12 @@ def check_int_stations(calh5parm,verbose=False,n_req=9):
         elif count<n_req:
             d['err']='too_few_international'
         else:
-            assert(v.shape[1]==len(a['ant']))
+            assert(v.shape[1]==len(a))
             nclock=v.shape[0]
             # Now check the flag fractions
             if verbose: print('Checking clock flag fractions')
             nffc=0
-            for i,ant in enumerate(a['ant']):
+            for i,ant in enumerate(a):
                 flagf=np.sum(np.isnan(v[:,i]))/nclock
                 if isint(ant):
                     if verbose: print("%-12s %7.2f%%" % (ant,100*flagf))
@@ -303,13 +305,12 @@ def check_int_stations(calh5parm,verbose=False,n_req=9):
                         if ant in good: good.remove(ant)
             d['flagged_clock']=nffc
 
-            bp=cal.getSoltab('bandpass')
-            v,a=bp.getValues()
-            assert(v.shape[2]==len(a['ant']))
+            v=data['calibrator']['bandpass']['val'][:]
+            assert(v.shape[2]==len(a))
             nbp=v.shape[0]*v.shape[1]*v.shape[3]
             if verbose: print('Checking bandpass flag fractions')
             nffb=0
-            for i,ant in enumerate(a['ant']):
+            for i,ant in enumerate(a):
                 flagf=np.sum(np.isnan(v[:,:,i,:]))/nbp
                 if isint(ant):
                     if verbose: print("%-12s %7.2f%%" % (ant,100*flagf))

--- a/calibrator_utils.py
+++ b/calibrator_utils.py
@@ -245,8 +245,8 @@ def download_calibrator(calid,dest):
 
 def check_cal_clock(calh5parm,verbose=False):
     data=h5py.File(calh5parm,'r')
-    cal = data.getSolset('calibrator')
-    soltabs = list(cal.getSoltabNames())
+    solset = 'calibrator'
+    soltabs = list(data[solset].keys())
     data.close()
     if verbose: print(soltabs)
     if 'clock' not in soltabs:
@@ -268,8 +268,8 @@ def check_int_stations(calh5parm,verbose=False,n_req=9):
     # Check number of int stations and flagging fraction for clock and bandpass
     if verbose: print('Opening',calh5parm)
     data=h5py.File(calh5parm,'r')
-    cal = data.getSolset('calibrator')
-    soltabs = list(cal.getSoltabNames())
+    solset = 'calibrator'
+    soltabs = list(data[solset].keys())
     if verbose: print('Solution tables are:',soltabs)
     d={}
     if 'clock' not in soltabs:
@@ -277,8 +277,10 @@ def check_int_stations(calh5parm,verbose=False,n_req=9):
     elif 'bandpass' not in soltabs:
         d['err']='no_bandpass'
     else:
-        clock=cal.getSoltab('clock')
-        v,a=clock.getValues()
+        a = data['calibrator']['clock']['ant'][:]
+        v = data['calibrator']['clock']['val'][:]
+        #clock=cal.getSoltab('clock')
+        #v,a=clock.getValues()
         good=[ant for ant in a['ant'] if isint(ant)]
         count=len(good)
         d['n_int']=count

--- a/calibrator_utils.py
+++ b/calibrator_utils.py
@@ -10,7 +10,7 @@ import subprocess
 import glob
 import fnmatch
 import datetime
-from losoto.h5parm import h5parm
+import h5py
 import numpy as np
 from reprocessing_utils import do_sdr_and_rclone_download, do_rclone_download
 
@@ -67,9 +67,9 @@ def get_linc( obsid, caldir ):
 
 def ddfpipeline_timecheck(name,soldir):
     do_sdr_and_rclone_download(name,soldir,verbose=False,Mode="Misc",operations=['download'])
-    untar_file(os.path.join(soldir,'misc.tar'),os.path.join(soldir,'tmp'),'*crossmatch-results-2.npy',os.path.join(soldir,'timetest-crossmatch-results-2.npy'))
-    ddftime = os.path.getmtime(os.path.join(soldir,'timetest-crossmatch-results-2.npy'))
-    os.system('rm {:s}'.format(os.path.join(soldir,'timetest-crossmatch-results-2.npy')))
+    untar_file(os.path.join(soldir,'misc.tar'),os.path.join(soldir,'tmp'),'*summary.txt',os.path.join(soldir,'timetest-summary.txt'))
+    ddftime = os.path.getmtime(os.path.join(soldir,'timetest-summary.txt'))
+    os.system('rm {:s}'.format(os.path.join(soldir,'timetest-summary.txt')))
     return(ddftime)
 
 def get_linc_for_ddfpipeline(macname,caldir):
@@ -244,7 +244,7 @@ def download_calibrator(calid,dest):
     rc.copy(rc.remote+'disk/surveys/'+str(calid)+'.tgz',dest)
 
 def check_cal_clock(calh5parm,verbose=False):
-    data=h5parm(calh5parm,'r')
+    data=h5py.File(calh5parm,'r')
     cal = data.getSolset('calibrator')
     soltabs = list(cal.getSoltabNames())
     data.close()
@@ -267,7 +267,7 @@ def isint(ant):
 def check_int_stations(calh5parm,verbose=False,n_req=9):
     # Check number of int stations and flagging fraction for clock and bandpass
     if verbose: print('Opening',calh5parm)
-    data=h5parm(calh5parm,'r')
+    data=h5py.File(calh5parm,'r')
     cal = data.getSolset('calibrator')
     soltabs = list(cal.getSoltabNames())
     if verbose: print('Solution tables are:',soltabs)


### PR DESCRIPTION
removed losoto h5parm and replaced with h5py to remove casacore dependency.

Using summary.txt to get the time of the ddf-pipeline run (instead of the crossmatch npy file which sometimes isnt in misc.tar for older runs)