### PR TITLE
multiple observations per field

### DIFF
--- a/lbfields_utils.py
+++ b/lbfields_utils.py
@@ -168,7 +168,7 @@ def stage_field( name, survey=None ):
     srmfilename = idd['srmfile']
     if srmfilename == 'multi':
         with SurveysDB(survey=survey) as sdb:
-            sdb.cur.execute('select * from observations where field=%s',(id,))
+            sdb.cur.execute('select * from observations where field=%s',(name,))
             obs = sdb.cur.fetchall()
         obs_ok = 0
         # check how many observations there really are, as opposed to failed on
@@ -184,7 +184,7 @@ def stage_field( name, survey=None ):
         else:
             print ('Multiple observations in one field not currently supported')
             print ('Updating status to Multiple')
-            update_status (id, 'Multiple')
+            update_status (name, 'Multiple')
             return(None)
     response = requests.get(srmfilename) 
     data = response.text

--- a/lbfields_utils.py
+++ b/lbfields_utils.py
@@ -171,15 +171,15 @@ def stage_field( name, survey=None ):
             sdb.cur.execute('select * from observations where field=%s',(id,))
             obs = sdb.cur.fetchall()
         obs_ok = 0
-        # check how many observations there really are, as opposed to failed on$
+        # check how many observations there really are, as opposed to failed on
         for nobs in range(len(obs)):
             if obs[nobs]['status'] in ['Archived','DI_Processed']:
                 obs_ok+=1
                 nobs_ok=nobs
         # If really only 1 observation, construct its srmfile and proceed
         if obs_ok==1:
-            srmfilename = 'https://public.spider.surfsara.nl/project/lotss/shim$
-        # multiple obs in 1 field complicated because ddflight, phaseup_concat $
+            srmfilename = 'https://public.spider.surfsara.nl/project/lotss/shimwell/LINC/srmfiles/srm%d.txt'%(obs[nobs_ok]['id'])
+        # multiple obs in 1 field complicated because ddflight, phaseup_concat need
         # data from all obs to be done at once; these to be left "for later"
         else:
             print ('Multiple observations in one field not currently supported')

--- a/monitor_lbfields.py
+++ b/monitor_lbfields.py
@@ -189,6 +189,8 @@ while True:
         stage_name=nextfield
         print('We need to stage a new field (%s)' % stage_name)
         solutions_name = stage_field(stage_name)
+        if solutions_name is None:  # multiple field ignored for now
+            continue
         ## while staging, collect the solutions
         solutions_thread=threading.Thread(target=collect_solutions, args=(solutions_name,))
         solutions_thread.start()


### PR DESCRIPTION
Handles multiple observations per field; checks if they are genuine multiple observations, in which case returns None from stage_field and changes status to 'multiple', continuing with next field; if not (e.g. COBALTERROR), makes up the srmfile from Tim's directories and returns the single observation as normal