### PR TITLE
Correct obsid from get_workflow_obsid for array job

### DIFF
--- a/lbfields_utils.py
+++ b/lbfields_utils.py
@@ -502,7 +502,7 @@ def get_workflow_obsid(outdir):
                 break
     tmp = line.split('.cwl')
     workflow = os.path.basename(tmp[0])
-    obsid = os.path.basename(outdir)
+    obsid = os.path.basename(outdir).split("_")[0]
     return(workflow,obsid)
 
 def check_field(field):


### PR DESCRIPTION
Added a small correction such that it gives the base obsid correctly. E.g.

123456 -> 123456
123456_5 -> 123456