### PR TITLE
Correct "linc-vlbi" to "target_VLBI"

### DIFF
--- a/monitor_lotsshr.py
+++ b/monitor_lotsshr.py
@@ -243,7 +243,7 @@ while True:
                 for obsid in field_obsids:
                     next_task = get_task_list(obsid)[0]
                     print('next task is',next_task)
-                    if next_task == 'target' or next_task == "linc-vlbi":
+                    if next_task == 'target' or next_task == "target_VLBI":
                         get_linc_inputs( field, obsid )                        
                     update_status(field,'Queued')
                     fieldobsid = '{:s}/{:s}'.format(field,obsid)


### PR DESCRIPTION
Missed one instance in a previous pull request.

Monitor script now also calls get_Linc_inputs when running LINC-VLBI.